### PR TITLE
refactor: used the parameter clientid is null, core clientid in the agent call url

### DIFF
--- a/adcio_agent/src/main/java/ai/corca/adcio_agent/agent/AgentClient.kt
+++ b/adcio_agent/src/main/java/ai/corca/adcio_agent/agent/AgentClient.kt
@@ -67,9 +67,8 @@ internal class AgentClient : Fragment(R.layout.fragment_adcio_agent) {
         fun postMessage(productId: String) {
             AdcioAgent(
                 context = requireContext().applicationContext,
-                clientId = "",
-                "",
-                0
+                baseUrl = "",
+                fragmentContainer = 0
             ).setProductId(productId)
         }
     }

--- a/adcio_agent/src/main/java/ai/corca/adcio_agent/provider/AdcioAgent.kt
+++ b/adcio_agent/src/main/java/ai/corca/adcio_agent/provider/AdcioAgent.kt
@@ -3,6 +3,7 @@ package ai.corca.adcio_agent.provider
 import ai.corca.adcio_agent.agent.AgentClient
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
+import com.corcaai.adcio_core.feature.AdcioCore
 import kotlin.properties.Delegates
 
 interface AdcioAgentListener {
@@ -17,7 +18,10 @@ private var _productId: String by Delegates.observable("") { _, _, new ->
 
 class AdcioAgent(
     val context: Context?,
-    val clientId: String,
+
+    // Your Adcio Client ID
+    // If not entered, the client entered at init will be set as the default value.
+    val clientId: String? = null,
 
     // A URL configuration parameter for library developers.
     // It has nothing to do with the clients, so please don't reveal it.
@@ -34,7 +38,7 @@ class AdcioAgent(
      */
     fun callAdcioAgent() {
         val startPage = "start/"
-        val agentUrl = "$baseUrl/$clientId/$startPage?platform=android&show_appbar=$showAppBar"
+        val agentUrl = "$baseUrl/${clientId ?: AdcioCore.clientId}/$startPage?platform=android&show_appbar=$showAppBar"
         val fragmentManager = (context as AppCompatActivity).supportFragmentManager
         val fragmentTransaction = fragmentManager.beginTransaction()
 

--- a/adcio_agent_compose/src/main/java/ai/corca/adcio_agent_compose/agent/AgentClient.kt
+++ b/adcio_agent_compose/src/main/java/ai/corca/adcio_agent_compose/agent/AgentClient.kt
@@ -7,6 +7,7 @@ import android.webkit.WebView
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.corcaai.adcio_core.feature.AdcioCore
 import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewState
 
@@ -24,7 +25,10 @@ private lateinit var webViewState: WebView
 @Composable
 fun AdcioAgent(
     modifier: Modifier = Modifier.fillMaxSize(),
-    clientId: String,
+
+    // Your Adcio Client ID
+    // If not entered, the client entered at init will be set as the default value.
+    clientId: String? = null,
 
     // A URL configuration parameter for library developers.
     // It has nothing to do with the clients, so please don't reveal it.
@@ -32,7 +36,7 @@ fun AdcioAgent(
     baseUrl: String = "https://agent.adcio.ai",
 ) {
     val startPage = "start/"
-    val agentUrl = "$baseUrl/$clientId/$startPage?platform=android&show_appbar=$showAppBar"
+    val agentUrl = "$baseUrl/${clientId ?: AdcioCore.clientId}/$startPage?platform=android&show_appbar=$showAppBar"
 
     WebView(
         modifier = modifier,


### PR DESCRIPTION
core 모듈 방식에 맞추어 agent에서 clientId 를 가져오는 방식을 변경하였습니다.

agent을 호출하는 함수 파라미터로 clientID optional 로 가져오고 clientid가 null 일 경우에 core의 clientId를 가져옵니다.