### PR TITLE
Feature/Update Exception in id setter if notinit

### DIFF
--- a/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
+++ b/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
@@ -30,7 +30,7 @@ class AdcioCoreTest {
     @TestOnly
     fun testClientIdNotInitialized() {
         val exception = assertThrows(NotInitializedException::class.java) {
-            AdcioCore.getClientId()
+            AdcioCore.clientId
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
 
@@ -42,7 +42,7 @@ class AdcioCoreTest {
     @TestOnly
     fun testStoreIdNotInitialized() {
         val exception = assertThrows(NotInitializedException::class.java) {
-            AdcioCore.getStoreId()
+            AdcioCore.storeId
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
     }
@@ -87,12 +87,12 @@ class AdcioCoreTest {
 
     @TestOnly
     fun testClientIdCreation() {
-        assertEquals("clientId", AdcioCore.getClientId())
+        assertEquals("clientId", AdcioCore.clientId)
     }
 
     @TestOnly
     fun testStoreIdCreation() {
-        assertEquals(AdcioCore.getClientId(), AdcioCore.getStoreId())
+        assertEquals(AdcioCore.clientId, AdcioCore.storeId)
     }
 
     @TestOnly

--- a/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
+++ b/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
@@ -12,10 +12,6 @@ import org.junit.Test
 
 class AdcioCoreTest {
 
-    companion object {
-        const val EXCEPTION_MESSAGE = "You must call init before using the core."
-    }
-
     @Before
     fun testIdNotInitialized() {
         testClientIdNotInitialized()

--- a/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
+++ b/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
@@ -29,10 +29,13 @@ class AdcioCoreTest {
      */
     @TestOnly
     fun testClientIdNotInitialized() {
-        val exception = assertThrows(NotInitializedException::class.java) {
+        val setterException = assertThrows(NotInitializedException::class.java) {
+            AdcioCore.clientId = ""
+        }
+        val getterException = assertThrows(NotInitializedException::class.java) {
             AdcioCore.clientId
         }
-        assertEquals(EXCEPTION_MESSAGE, exception.message)
+        assertEquals(setterException.message, getterException.message)
     }
 
     /**
@@ -40,10 +43,13 @@ class AdcioCoreTest {
      */
     @TestOnly
     fun testSessionIdNotInitialized() {
-        val exception = assertThrows(NotInitializedException::class.java) {
+        val setterException = assertThrows(NotInitializedException::class.java) {
+            AdcioCore.sessionId = ""
+        }
+        val getterException = assertThrows(NotInitializedException::class.java) {
             AdcioCore.sessionId
         }
-        assertEquals(EXCEPTION_MESSAGE, exception.message)
+        assertEquals(setterException.message, getterException.message)
     }
 
     /**
@@ -51,10 +57,13 @@ class AdcioCoreTest {
      */
     @TestOnly
     fun testDeviceIdNotInitialized() {
-        val exception = assertThrows(NotInitializedException::class.java) {
+        val setterException = assertThrows(NotInitializedException::class.java) {
+            AdcioCore.deviceId = ""
+        }
+        val getterException = assertThrows(NotInitializedException::class.java) {
             AdcioCore.deviceId
         }
-        assertEquals(EXCEPTION_MESSAGE, exception.message)
+        assertEquals(setterException.message, getterException.message)
     }
 
     /**
@@ -62,10 +71,13 @@ class AdcioCoreTest {
      */
     @TestOnly
     fun testStoreIdNotInitialized() {
-        val exception = assertThrows(NotInitializedException::class.java) {
+        val setterException = assertThrows(NotInitializedException::class.java) {
+            AdcioCore.storeId = ""
+        }
+        val getterException = assertThrows(NotInitializedException::class.java) {
             AdcioCore.storeId
         }
-        assertEquals(EXCEPTION_MESSAGE, exception.message)
+        assertEquals(setterException.message, getterException.message)
     }
 
     @Test

--- a/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
+++ b/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
@@ -33,7 +33,6 @@ class AdcioCoreTest {
             AdcioCore.clientId
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
-
     }
 
     /**

--- a/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
+++ b/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
@@ -12,6 +12,10 @@ import org.junit.Test
 
 class AdcioCoreTest {
 
+    companion object {
+        const val EXCEPTION_MESSAGE = "You must call init before using the core."
+    }
+
     @Before
     fun testIdNotInitialized() {
         testClientIdNotInitialized()
@@ -25,13 +29,22 @@ class AdcioCoreTest {
      */
     @TestOnly
     fun testClientIdNotInitialized() {
-        val setterException = assertThrows(NotInitializedException::class.java) {
-            AdcioCore.clientId = ""
+        val exception = assertThrows(NotInitializedException::class.java) {
+            AdcioCore.getClientId()
         }
-        val getterException = assertThrows(NotInitializedException::class.java) {
-            AdcioCore.clientId
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+
+    }
+
+    /**
+     * A test that raises a NotInitializedException by accessing the storeId before init.
+     */
+    @TestOnly
+    fun testStoreIdNotInitialized() {
+        val exception = assertThrows(NotInitializedException::class.java) {
+            AdcioCore.getStoreId()
         }
-        assertEquals(setterException.message, getterException.message)
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
     }
 
     /**
@@ -62,20 +75,6 @@ class AdcioCoreTest {
         assertEquals(setterException.message, getterException.message)
     }
 
-    /**
-     * A test that raises a NotInitializedException by accessing the storeId before init.
-     */
-    @TestOnly
-    fun testStoreIdNotInitialized() {
-        val setterException = assertThrows(NotInitializedException::class.java) {
-            AdcioCore.storeId = ""
-        }
-        val getterException = assertThrows(NotInitializedException::class.java) {
-            AdcioCore.storeId
-        }
-        assertEquals(setterException.message, getterException.message)
-    }
-
     @Test
     fun testCoreIdCreation() {
         AdcioCore.initializeApp("clientId")
@@ -88,7 +87,12 @@ class AdcioCoreTest {
 
     @TestOnly
     fun testClientIdCreation() {
-        assertEquals("clientId", AdcioCore.clientId)
+        assertEquals("clientId", AdcioCore.getClientId())
+    }
+
+    @TestOnly
+    fun testStoreIdCreation() {
+        assertEquals(AdcioCore.getClientId(), AdcioCore.getStoreId())
     }
 
     @TestOnly
@@ -99,11 +103,6 @@ class AdcioCoreTest {
     @TestOnly
     fun testDeviceIdCreation() {
         assertEquals(Build.ID, AdcioCore.deviceId)
-    }
-
-    @TestOnly
-    fun testStoreIdCreation() {
-        assertEquals(AdcioCore.clientId, AdcioCore.storeId)
     }
 
     @After

--- a/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
+++ b/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
@@ -112,6 +112,7 @@ class AdcioCoreTest {
 
         testDeviceIdValuePreservation()
         testSessionIdValuePreservation()
+        testAfterAgainInitSessionIdValuePreservation()
     }
 
     @TestOnly
@@ -127,6 +128,14 @@ class AdcioCoreTest {
     fun testSessionIdValuePreservation() {
         val sessionId1 = AdcioCore.sessionId
         Thread.sleep(1000)
+        val sessionId2 = AdcioCore.sessionId
+
+        assertEquals(sessionId1, sessionId2)
+    }
+
+    @TestOnly
+    fun testAfterAgainInitSessionIdValuePreservation() {
+        val sessionId1 = AdcioCore.sessionId
         AdcioCore.initializeApp("")
         val sessionId2 = AdcioCore.sessionId
 

--- a/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
+++ b/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
@@ -127,6 +127,7 @@ class AdcioCoreTest {
     fun testSessionIdValuePreservation() {
         val sessionId1 = AdcioCore.sessionId
         Thread.sleep(1000)
+        AdcioCore.initializeApp("")
         val sessionId2 = AdcioCore.sessionId
 
         assertEquals(sessionId1, sessionId2)

--- a/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
+++ b/adcio_core/src/androidTest/java/com/corcaai/AdcioCoreTest.kt
@@ -115,28 +115,28 @@ class AdcioCoreTest {
 
     @TestOnly
     fun testDeviceIdValuePreservation() {
-        val deviceId1 = AdcioCore.deviceId
+        val oldDeviceId = AdcioCore.deviceId
         Thread.sleep(1000)
-        val deviceId2 = AdcioCore.deviceId
+        val newDeviceId = AdcioCore.deviceId
 
-        assertEquals(deviceId1, deviceId2)
+        assertEquals(oldDeviceId, newDeviceId)
     }
 
     @TestOnly
     fun testSessionIdValuePreservation() {
-        val sessionId1 = AdcioCore.sessionId
+        val oldSessionId = AdcioCore.sessionId
         Thread.sleep(1000)
-        val sessionId2 = AdcioCore.sessionId
+        val newSessionId = AdcioCore.sessionId
 
-        assertEquals(sessionId1, sessionId2)
+        assertEquals(oldSessionId, newSessionId)
     }
 
     @TestOnly
     fun testAfterAgainInitSessionIdValuePreservation() {
-        val sessionId1 = AdcioCore.sessionId
+        val oldSessionId = AdcioCore.sessionId
         AdcioCore.initializeApp("")
-        val sessionId2 = AdcioCore.sessionId
+        val newSessionId = AdcioCore.sessionId
 
-        assertEquals(sessionId1, sessionId2)
+        assertEquals(oldSessionId, newSessionId)
     }
 }

--- a/adcio_core/src/main/java/com/corcaai/adcio_core/feature/AdcioCore.kt
+++ b/adcio_core/src/main/java/com/corcaai/adcio_core/feature/AdcioCore.kt
@@ -10,24 +10,24 @@ object AdcioCore {
     private var sessionIdValue: String? = null
 
     fun initializeApp(id: String) {
-        isInitialized = true
         clientId = id
+        isInitialized = true
     }
 
     /**
      * You can obtain the clientId registered.
      */
-    var clientId: String = ""
-        set(value) {
-            if (!isInitialized) throw NotInitializedException()
-            field = value
-        }
-        get() {
-            if (!isInitialized) throw NotInitializedException()
+    private var clientId: String = ""
 
-            // Returns the clientId you entered during init
-            return field
-        }
+    fun getClientId(): String {
+        if (!isInitialized) throw NotInitializedException()
+        return clientId
+    }
+
+    fun getStoreId(): String {
+        if (!isInitialized) throw NotInitializedException()
+        return clientId
+    }
 
     /**
      * You can obtain the sessionId registered.
@@ -57,19 +57,5 @@ object AdcioCore {
             if (!isInitialized) throw NotInitializedException()
             // Generate and return device id
             return field.takeIf { it.isNotBlank() } ?: Build.ID
-        }
-
-    /**
-     * You can obtain the storeId registered.
-     */
-    var storeId: String? = null
-        set(value) {
-            if (!isInitialized) throw NotInitializedException()
-            field = value
-        }
-        get() {
-            if (!isInitialized) throw NotInitializedException()
-            // If empty, returns clientId
-            return field ?: clientId
         }
 }

--- a/adcio_core/src/main/java/com/corcaai/adcio_core/feature/AdcioCore.kt
+++ b/adcio_core/src/main/java/com/corcaai/adcio_core/feature/AdcioCore.kt
@@ -10,29 +10,34 @@ object AdcioCore {
     private var sessionIdValue: String? = null
 
     fun initializeApp(id: String) {
-        clientId = id
         isInitialized = true
+        clientId = id
     }
 
     /**
      * You can obtain the clientId registered.
      */
-    private var clientId: String = ""
+    var clientId: String = ""
+        private set
+        get() {
+            if (!isInitialized) throw NotInitializedException()
+            return field
+        }
 
-    fun getClientId(): String {
-        if (!isInitialized) throw NotInitializedException()
-        return clientId
-    }
-
-    fun getStoreId(): String {
-        if (!isInitialized) throw NotInitializedException()
-        return clientId
-    }
+    /**
+     * You can obtain the storeId registered.
+     */
+    var storeId: String? = null
+        private set
+        get() {
+            if (!isInitialized) throw NotInitializedException()
+            return clientId
+        }
 
     /**
      * You can obtain the sessionId registered.
      */
-    var sessionId: String
+     var sessionId: String
         set(value) {
             if (!isInitialized) throw NotInitializedException()
             sessionIdValue = value

--- a/adcio_core/src/main/java/com/corcaai/adcio_core/feature/AdcioCore.kt
+++ b/adcio_core/src/main/java/com/corcaai/adcio_core/feature/AdcioCore.kt
@@ -37,7 +37,7 @@ object AdcioCore {
     /**
      * You can obtain the sessionId registered.
      */
-     var sessionId: String
+    var sessionId: String
         set(value) {
             if (!isInitialized) throw NotInitializedException()
             sessionIdValue = value

--- a/adcio_core/src/main/java/com/corcaai/adcio_core/feature/AdcioCore.kt
+++ b/adcio_core/src/main/java/com/corcaai/adcio_core/feature/AdcioCore.kt
@@ -7,16 +7,21 @@ import java.util.UUID
 object AdcioCore {
 
     private var isInitialized: Boolean = false
+    private var sessionIdValue: String? = null
 
     fun initializeApp(id: String) {
-        clientId = id
         isInitialized = true
+        clientId = id
     }
 
     /**
      * You can obtain the clientId registered.
      */
     var clientId: String = ""
+        set(value) {
+            if (!isInitialized) throw NotInitializedException()
+            field = value
+        }
         get() {
             if (!isInitialized) throw NotInitializedException()
 
@@ -24,13 +29,12 @@ object AdcioCore {
             return field
         }
 
-    private var sessionIdValue: String? = null
-
     /**
      * You can obtain the sessionId registered.
      */
     var sessionId: String
         set(value) {
+            if (!isInitialized) throw NotInitializedException()
             sessionIdValue = value
         }
         get() {
@@ -45,6 +49,10 @@ object AdcioCore {
      * You can obtain the deviceId registered.
      */
     var deviceId: String = ""
+        set(value) {
+            if (!isInitialized) throw NotInitializedException()
+            field = value
+        }
         get() {
             if (!isInitialized) throw NotInitializedException()
             // Generate and return device id
@@ -55,6 +63,10 @@ object AdcioCore {
      * You can obtain the storeId registered.
      */
     var storeId: String? = null
+        set(value) {
+            if (!isInitialized) throw NotInitializedException()
+            field = value
+        }
         get() {
             if (!isInitialized) throw NotInitializedException()
             // If empty, returns clientId


### PR DESCRIPTION
코어에 변동사항 논의 이후 core 기능을 업데이트합니다.

Init 하지 않고 core Id Setter시 NotInitalizedException 추가
clientId & storeId setter 안되도록 private 설정 후 id를 get하는 함수 생성

Core init 함수 이름 init -> initializeApp 변경은 예전 PR 에서 변경 완료.

이 두분 반영하고 release 파서 core 0.1.1 릴리즈 예정