### PR TITLE
ADCIO-2215) refactor: migration gradle convention plugins

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,11 +1,24 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import DependencyHandler.Extensions.implementations
+
 plugins {
     `kotlin-dsl`
+    alias(libs.plugins.kotlin.dokka)
+    alias(libs.plugins.util.dependency.handler.extensions)
+    alias(libs.plugins.local.convention.enum)
 }
 
 group = "ai.corca.local"
 
 dependencies {
-
+    implementations(
+        libs.kotlin.core,
+        libs.kotlin.dokka.base,
+        libs.kotlin.dokka.plugin,
+        libs.build.gradle.agp,
+        libs.build.dependency.handler.extensions,
+        libs.build.local.plugin.enum
+    )
+    compileOnly(libs.ksp.gradlePlugin)
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,11 @@
+@file:Suppress("DSL_SCOPE_VIOLATION")
+
+plugins {
+    `kotlin-dsl`
+}
+
+group = "ai.corca.local"
+
+dependencies {
+
+}

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
+org.gradle.configureondemand=true
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/build-logic/local-enums/build.gradle.kts
+++ b/build-logic/local-enums/build.gradle.kts
@@ -1,0 +1,20 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    `kotlin-dsl`
+    `maven-publish`
+}
+
+group = "ai.corca.local"
+version = "master"
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
+}

--- a/build-logic/local-enums/build.gradle.kts
+++ b/build-logic/local-enums/build.gradle.kts
@@ -8,6 +8,19 @@ plugins {
 group = "ai.corca.local"
 version = "master"
 
+gradlePlugin {
+    plugins {
+        create("conventionEnumPlugin") {
+            id = "ai.corca.local.convention.enum"
+            implementationClass = "ConventionEnum"
+        }
+        create("pluginEnumPlugin") {
+            id = "ai.corca.local.plugin.enum"
+            implementationClass = "PluginEnum"
+        }
+    }
+}
+
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         jvmTarget = "17"

--- a/build-logic/local-enums/settings.gradle.kts
+++ b/build-logic/local-enums/settings.gradle.kts
@@ -1,0 +1,10 @@
+@file:Suppress("UnstableApiUsage")
+
+rootProject.name = "local-enums"
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/build-logic/local-enums/src/main/kotlin/ConventionEnum.kt
+++ b/build-logic/local-enums/src/main/kotlin/ConventionEnum.kt
@@ -1,0 +1,23 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class ConventionEnum: Plugin<Project> {
+    override fun apply(target: Project) = Unit
+
+    companion object {
+        private const val prefix = "corcaai"
+
+        const val AppVersionNameProvider = "$prefix.app.version.name.provider"
+
+        const val AndroidApplication = "$prefix.android.application"
+        const val AndroidApplicationCompose = "$prefix.android.application.compose"
+
+        const val AndroidLibrary = "$prefix.android.library"
+        const val AndroidLibraryCompose = "$prefix.android.library.compose"
+        const val AndroidLibraryComposeUiTest = "$prefix.android.library.compose.uitest"
+
+        const val JvmLibrary = "$prefix.jvm.library"
+        const val JvmJUnit4 = "$prefix.jvm.junit4"
+        const val JvmDokka = "$prefix.jvm.dokka"
+    }
+}

--- a/build-logic/local-enums/src/main/kotlin/PluginEnum.kt
+++ b/build-logic/local-enums/src/main/kotlin/PluginEnum.kt
@@ -1,0 +1,18 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class PluginEnum : Plugin<Project> {
+    override fun apply(target: Project) = Unit
+
+    companion object {
+        const val KotlinCore = "kotlin"
+        const val KotlinKapt = "kotlin-kapt"
+        const val KotlinAndroid = "kotlin-android"
+
+        const val JavaLibrary = "java-library"
+
+        const val AndroidApplication = "com.android.application"
+        const val AndroidLibrary = "com.android.library"
+        const val AndroidDfm = "com.android.dynamic-feature"
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,25 @@
+@file:Suppress("UnstableApiUsage")
+
+rootProject.name = "build-logic"
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        mavenLocal()
+    }
+
+    pluginManagement {
+        repositories {
+            mavenLocal()
+            mavenCentral()
+            gradlePluginPortal()
+        }
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/AndroidApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidApplicationPlugin.kt
@@ -1,0 +1,35 @@
+@file:Suppress("UnstableApiUsage")
+
+import ai.corca.convention.ApplicationConstants
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+internal class AndroidApplicationPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            applyPlugins(
+                PluginEnum.AndroidApplication,
+                PluginEnum.KotlinAndroid,
+            )
+
+            extensions.configure<BaseAppModuleExtension> {
+                configureApplication(this)
+
+                defaultConfig {
+                    targetSdk = ApplicationConstants.targetSdk
+                    versionName = ApplicationConstants.versionName
+                    versionCode = ApplicationConstants.versionCode
+                }
+
+                 buildTypes {
+                     release {
+                         isShrinkResources = true
+                         isMinifyEnabled = true
+                     }
+                 }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/ai/corca/convention/ApplicationConstants.kt
+++ b/build-logic/src/main/kotlin/ai/corca/convention/ApplicationConstants.kt
@@ -1,0 +1,11 @@
+package ai.corca.convention
+
+import org.gradle.api.JavaVersion
+internal object ApplicationConstants {
+    const val minSdk = 24
+    const val targetSdk = 33
+    const val compileSdk = 33
+    const val versionCode = 32
+    const val versionName = "1.4.0"
+    val javaVersion = JavaVersion.VERSION_17
+}

--- a/build-logic/src/main/kotlin/ai/corca/convention/ApplicationConstants.kt
+++ b/build-logic/src/main/kotlin/ai/corca/convention/ApplicationConstants.kt
@@ -1,6 +1,7 @@
 package ai.corca.convention
 
 import org.gradle.api.JavaVersion
+
 internal object ApplicationConstants {
     const val minSdk = 24
     const val targetSdk = 33

--- a/build-logic/src/main/kotlin/ai/corca/convention/ApplicationConstants.kt
+++ b/build-logic/src/main/kotlin/ai/corca/convention/ApplicationConstants.kt
@@ -7,6 +7,6 @@ internal object ApplicationConstants {
     const val targetSdk = 33
     const val compileSdk = 33
     const val versionCode = 32
-    const val versionName = "1.4.0"
+    const val versionName = "1.0"
     val javaVersion = JavaVersion.VERSION_17
 }

--- a/build-logic/src/main/kotlin/ai/corca/convention/application.kt
+++ b/build-logic/src/main/kotlin/ai/corca/convention/application.kt
@@ -1,0 +1,28 @@
+@file:Suppress("UnstableApiUsage", "UnusedReceiverParameter")
+
+import ai.corca.convention.ApplicationConstants
+import org.gradle.api.Project
+import com.android.build.api.dsl.CommonExtension
+
+internal fun Project.configureApplication(extension: CommonExtension<*, *, *, *>) {
+    extension.apply {
+        compileSdk = ApplicationConstants.compileSdk
+
+        defaultConfig {
+            minSdk = ApplicationConstants.minSdk
+        }
+
+        sourceSets {
+            getByName("main").java.srcDirs("src/main/kotlin/")
+        }
+
+        compileOptions {
+            sourceCompatibility = ApplicationConstants.javaVersion
+            targetCompatibility = ApplicationConstants.javaVersion
+        }
+
+        lint {
+            checkTestSources = true
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/ai/corca/convention/compose.kt
+++ b/build-logic/src/main/kotlin/ai/corca/convention/compose.kt
@@ -1,0 +1,4 @@
+@file:Suppress("UnstableApiUsage")
+
+// internal fun Project.configureComposeO(extension: CommenExtension)8
+

--- a/build-logic/src/main/kotlin/ai/corca/convention/extensions.kt
+++ b/build-logic/src/main/kotlin/ai/corca/convention/extensions.kt
@@ -1,0 +1,44 @@
+@file:Suppress("SameParameterValue")
+
+import DependencyHandler.Extensions.debugImplementations
+import DependencyHandler.Extensions.implementations
+import DependencyHandler.Extensions.testImplementations
+import DependencyHandler.Extensions.testRuntimeOnlys
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.NamedDomainObjectContainerScope
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+
+internal val Project.libs
+    get() = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+internal fun Project.applyPlugins(vararg plugins: String) {
+    plugins.forEach { plugin ->
+        pluginManager.apply(plugin)
+    }
+}
+
+internal fun CommonExtension<*, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
+    (this as ExtensionAware).extensions.configure("kotlinOptions", block)
+}
+
+@Suppress("nothing_to_inline")
+internal inline operator fun <T : Any, C : NamedDomainObjectContainer<T>> C.invoke(
+    configuration: Action<NamedDomainObjectContainerScope<T>>,
+) = apply { configuration.execute(NamedDomainObjectContainerScope.of(this)) }
+
+internal fun DependencyHandler.setupJunit(core: Any, engine: Any) {
+    testImplementations(core)
+    testRuntimeOnlys(engine)
+}
+
+internal fun DependencyHandler.setupCompose(core: Any, debug: Any) {
+    implementations(core)
+    debugImplementations(debug)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,93 @@
+[versions]
+# plugin
+plugin-build-gradle-android = "8.0.2"
+plugin-kotlin-ksp = "1.8.10-1.0.9"
+
+# Android
+androidx-appcompat = "1.6.1"
+androidx-material = "1.9.0"
+androidx-constriantLayout = "2.1.4"
+androidx-core-ktx = "1.10.1"
+
+# Test
+test-junit = "4.13.2"
+test-extJunit = "1.1.5"
+test-jupiter = "5.10.1"
+test-espresso = "3.5.1"
+test-mock = "1.13.8"
+
+# Jetpack Compose
+compose-core = "1.5.4"
+compose-activity = "1.8.2"
+compose-navigation = "2.7.6"
+compose-accompanist = "0.31.6-rc"
+
+# Retrofit
+retrofit = "2.9.0"
+
+# OkHTTP
+okhttp = "4.9.0"
+
+# Glide
+glide = "4.16.0"
+
+# ADCIO
+adcio-core = "0.1.3"
+adcio-analytics = "0.1.3"
+
+# Plugin
+kotlin-core = "1.8.10"
+kotlin-dokka = "1.9.10"
+plugin-util-dependency-handler-extensions = "1.0.3"
+plugin-local-master = "master"
+
+[plugins]
+
+kotlin-dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin-dokka" }
+
+util-dependency-handler-extensions = { id = "land.sungbin.dependency.handler.extensions", version.ref = "plugin-util-dependency-handler-extensions" }
+
+local-convention-enum = { id = "ai.corca.local.convention.enum", version.ref = "plugin-local-master" }
+
+[libraries]
+
+build-gradle-agp = { module = "com.android.tools.build:gradle", version.ref = "plugin-build-gradle-android" }
+build-local-plugin-enum = { module = "ai.corca.local:local-enums", version.ref = "plugin-local-master" }
+
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-material = { module = "com.google.android.material:material", version.ref = "androidx-material" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constriantLayout" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
+
+build-dependency-handler-extensions = { module = "land.sungbin.dependency.handler.extensions:dependency-handler-extensions-plugin", version.ref = "plugin-util-dependency-handler-extensions" }
+
+kotlin-core = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-core" }
+kotlin-dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "kotlin-dokka" }
+kotlin-dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin-dokka" }
+
+test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "test-extJunit" }
+test-jupiter = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "test-jupiter" }
+test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "test-espresso" }
+test-mock = { module = "io.mockk:mockk-android", version.ref = "test-mock" }
+
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-json = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
+okhttp = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+
+compose-material = { module = "androidx.compose.material:material", version.ref = "compose-core" }
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose-core" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-core" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-core" }
+compose-activity = { module = "androidx.activity:activity-compose", version.ref = "compose-activity" }
+compose-navigation = { module = "androidx.navigation:navigation-compose", version.ref = "compose-navigation" }
+compose-accompanist = { module = "com.google.accompanist:accompanist-webview", version.ref = "compose-accompanist" }
+
+ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "plugin-kotlin-ksp" }
+
+adcio-core = { module = "io.github.corca-ai:adcio_core", version.ref = "adcio-core" }
+adcio-analytics = { module = "io.github.corca-ai:adcio_analytics", version.ref = "adcio-analytics" }
+
+[bundles]
+compose-core = ["compose-material", "compose-activity", "compose-ui", "compose-ui-tooling-preview", "compose-navigation"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,22 +1,28 @@
-pluginManagement {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
+@file:Suppress("UnstableApiUsage")
 
 rootProject.name = "adcio_android_plugins"
-include(":app")
-include(":adcio_placement")
-include(":adcio_agent")
-include(":adcio_analytics")
-include(":adcio_agent_compose")
-include(":adcio_core")
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+pluginManagement {
+    pluginManagement {
+        repositories {
+            google()
+            mavenCentral()
+            gradlePluginPortal()
+        }
+    }
+
+    includeBuild("build-logic")
+    includeBuild("build-logic/local-enums")
+}
+
+
+include(
+    ":app",
+    ":adcio_placement",
+    ":adcio_agent",
+    ":adcio_analytics",
+    ":adcio_agent_compose",
+    ":adcio_core",
+)


### PR DESCRIPTION
♻️ Current situation
gradle의 dependencies 관리 방식을 gradle convention plugins으로 마이그레이션 합니다.
dependencies 값들을 toml 파일에서 관리 하도록 마이그레이션 합니다.

💡 Proposed solution
gradle의 dependencies 관리 방식을 마이그레이션 함으로써 유지보수성을 증가시키고 빌드 시간을 단축시킵니다.
toml 파일에서 dependencies 값들을 관리 함으로써 gradle sync 시간을 단축 시키고 효율적인 버전 관리를 지원합니다.